### PR TITLE
Support `U(L-1, ...)` and tolerate looser schedule strings

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -28,7 +28,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
     }
     case 'U':
     {
-        std::string regex_str = "U\\(L(\\d),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
+        std::string regex_str = "U\\(L(-?\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
         std::regex_search(action_str, match, re);
@@ -38,7 +38,45 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
         auto comps = get_comps(comps_str, implicit_function);
 
+        if (level == -1)
+        {
+            // Resolve "innermost loop" against the current schedule, which
+            // reflects previously applied actions (e.g. tile). Cross-comp
+            // mismatch is detected via the iteration domain (untouched by
+            // align_schedules' padding) so we catch the gemver-style case
+            // where A_hat is 2D and x is 1D even if their schedules have
+            // already been padded to a common width by an earlier
+            // prepare_schedules_for_legality_checks().
+            // Schedule layout is [0, 0, i1, 0, i2, 0, ...]
+            // (see loop_level_into_dynamic_dimension in tiramisu_core.cpp);
+            // loop count = (out_dims - 2) / 2.
+            if (comps.empty())
+            {
+                throw std::invalid_argument(
+                    "U(L-1,...): no computations to unroll");
+            }
+            auto iter_dim_of = [](tiramisu::computation *c) {
+                return isl_set_dim(c->get_iteration_domain(), isl_dim_set);
+            };
+            int reference_iter_dim = iter_dim_of(comps.front());
+            for (auto comp : comps)
+            {
+                if (iter_dim_of(comp) != reference_iter_dim)
+                {
+                    throw std::invalid_argument(
+                        "U(L-1,...) requires all target computations to "
+                        "share the same innermost loop depth. Split "
+                        "non-perfectly-nested computations into separate "
+                        "U(...) actions.");
+                }
+            }
+            int sched_dims =
+                isl_map_dim(comps.front()->get_schedule(), isl_dim_out);
+            level = (sched_dims - 2) / 2 - 1;
+        }
+
         tiramisu::prepare_schedules_for_legality_checks(true);
+
         is_legal = loop_unrolling_is_legal(level, comps);
 
         for (auto comp : comps)

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -334,6 +334,14 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
 
 bool apply_actions_from_schedule_str(std::string schedule_str, tiramisu::function *implicit_function, Result &result)
 {
+    // Normalize: drop all whitespace and canonicalize quotes so the
+    // per-action regexes can stay strict. Tiramisu identifiers are \w+,
+    // so stripping whitespace inside the schedule string is lossless.
+    schedule_str.erase(std::remove_if(schedule_str.begin(), schedule_str.end(),
+                                      [](unsigned char c) { return std::isspace(c); }),
+                       schedule_str.end());
+    std::replace(schedule_str.begin(), schedule_str.end(), '"', '\'');
+
     std::string delimiter = "|";
     size_t pos = 0;
     std::string token;

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -331,6 +331,79 @@ TEST(TiraLibCppTest, Unrolling)
             clean_halide_ir(halide_ir));
 }
 
+TEST(TiraLibCppTest, UnrollingLNeg1)
+{
+  std::string schedule = "U(L-1,32,comps=['comp_blur'])";
+  auto result = apply_schedule_blur(schedule);
+
+  Result resultInstance = std::get<0>(result);
+  std::string halide_ir = std::get<1>(result);
+
+  std::string function_name = "function_blur_MINI";
+
+  tiramisu::init(function_name);
+
+  var xi("xi", 0, 34), yi("yi", 0, 18), ci("ci", 0, 5);
+  var x("x", 1, 34 - 1), y("y", 1, 18 - 1), c("c", 1, 5 - 1);
+
+  input input_img("input_img", {ci, yi, xi}, p_float64);
+
+  computation comp_blur("comp_blur", {c, y, x}, (input_img(c, y + 1, x - 1) + input_img(c, y + 1, x) + input_img(c, y + 1, x + 1) + input_img(c, y, x - 1) + input_img(c, y, x) + input_img(c, y, x + 1) + input_img(c, y - 1, x - 1) + input_img(c, y - 1, x) + input_img(c, y - 1, x + 1)) * 0.111111);
+
+  buffer input_buf("input_buf", {5, 18, 34}, p_float64, a_input);
+  buffer output_buf("output_buf", {5, 18, 34}, p_float64, a_output);
+
+  input_img.store_in(&input_buf);
+  comp_blur.store_in(&output_buf);
+
+  auto buffers = {&input_buf, &output_buf};
+
+  // L-1 on comp_blur (3 loops c,y,x) resolves to level 2.
+  comp_blur.unroll(2, 32);
+
+  EXPECT_EQ(global::get_implicit_function()->get_name(), function_name);
+  EXPECT_EQ(clean_halide_ir(global::get_implicit_function()->get_halide_ir(buffers)),
+            clean_halide_ir(halide_ir));
+}
+
+TEST(TiraLibCppTest, UnrollingLNeg1AfterTiling)
+{
+  // After T2 adds two loops, the innermost level for comp_blur is 4.
+  // We verify L-1 resolution via the schedule dim formula it uses
+  // ((isl_map_dim(schedule, isl_dim_out) - 2) / 2 - 1). Running the full
+  // U(L-1,...) action through apply_schedule_blur after a tile triggers a
+  // pre-existing Tiramisu bound-extraction failure inside
+  // computation::separateAndSplit that is unrelated to L-1.
+  std::string function_name = "function_blur_MINI";
+
+  tiramisu::init(function_name);
+
+  var xi("xi", 0, 34), yi("yi", 0, 18), ci("ci", 0, 5);
+  var x("x", 1, 34 - 1), y("y", 1, 18 - 1), c("c", 1, 5 - 1);
+
+  input input_img("input_img", {ci, yi, xi}, p_float64);
+
+  computation comp_blur("comp_blur", {c, y, x}, (input_img(c, y + 1, x - 1) + input_img(c, y + 1, x) + input_img(c, y + 1, x + 1) + input_img(c, y, x - 1) + input_img(c, y, x) + input_img(c, y, x + 1) + input_img(c, y - 1, x - 1) + input_img(c, y - 1, x) + input_img(c, y - 1, x + 1)) * 0.111111);
+
+  buffer input_buf("input_buf", {5, 18, 34}, p_float64, a_input);
+  buffer output_buf("output_buf", {5, 18, 34}, p_float64, a_output);
+
+  input_img.store_in(&input_buf);
+  comp_blur.store_in(&output_buf);
+
+  auto innermost_of = [](tiramisu::computation &c) {
+    return (isl_map_dim(c.get_schedule(), isl_dim_out) - 2) / 2 - 1;
+  };
+
+  EXPECT_EQ(innermost_of(comp_blur), 2);
+
+  Result result;
+  apply_action("T2(L0,L1,32,32,comps=['comp_blur'])",
+               global::get_implicit_function(), result);
+
+  EXPECT_EQ(innermost_of(comp_blur), 4);
+}
+
 TEST(TiraLibCppTest, Interchange)
 {
   std::string schedule = "I(L0,L1,comps=['comp_blur'])";
@@ -744,6 +817,14 @@ TEST(TiraLibCppTest, FusionLegal)
   EXPECT_EQ(resultInstance.legality, true);
   EXPECT_EQ(global::get_implicit_function()->get_name(), "function_gemver_MINI");
   EXPECT_EQ(clean_halide_ir(global::get_implicit_function()->get_halide_ir({&b_A, &b_u1, &b_u2, &b_v1, &b_v2, &b_y, &b_z, &b_A_hat, &b_x, &b_w})), clean_halide_ir(halide_ir));
+}
+
+TEST(TiraLibCppTest, UnrollingLNeg1Mismatch)
+{
+  // A_hat is 2D (innermost level 1); x is 1D (innermost level 0).
+  // U(L-1,...) over both must reject the action.
+  std::string schedule = "U(L-1,4,comps=['A_hat', 'x'])";
+  EXPECT_THROW(apply_schedule_multi_comp_sample(schedule), std::invalid_argument);
 }
 
 TEST(TiraLibCppTest, Matrix)


### PR DESCRIPTION
Mirror of the TiraLib change [#56](https://github.com/Tiramisu-Compiler/TiraLib/pull/56). The `U` branch in `apply_action` resolves `L-1` to the post-transformation innermost loop on each comp (via the schedule's output-dim count). Cross-comp depth mismatches throw `std::invalid_argument`; mismatch is detected against the iteration domain so `align_schedules` padding doesn't hide it.

`apply_actions_from_schedule_str` strips whitespace and canonicalizes quotes once before tokenizing, so existing per-action regexes don't need to be loosened.

Tests added in `tests/actions_test.cc`: standalone L-1, L-1 after a tile (verified via schedule dim count), and the multi-comp mismatch case.