### PR TITLE
Catch invalid schedule tokens in `apply_action`

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -4,6 +4,16 @@
 #include <TiraLibCPP/utils.h>
 #include <TiraLibCPP/dbhelpers.h>
 
+static void parse_or_throw(const std::string &action_str, std::smatch &match,
+                           const std::regex &re)
+{
+    if (!std::regex_search(action_str, match, re))
+    {
+        throw std::invalid_argument(
+            "Failed to parse schedule token: " + action_str);
+    }
+}
+
 bool apply_action(std::string action_str, tiramisu::function *implicit_function, Result &result)
 {
     bool is_legal = true;
@@ -14,7 +24,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "P\\(L(\\d),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level = std::stoi(match[1]);
         std::string comps_str = match[2];
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
@@ -31,7 +41,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "U\\(L(-?\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level = std::stoi(match[1]);
         int factor = std::stoi(match[2]);
         std::string comps_str = match[3];
@@ -90,7 +100,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "I\\(L(\\d),L(\\d),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level1 = std::stoi(match[1]);
         int level2 = std::stoi(match[2]);
         std::string comps_str = match[3];
@@ -107,7 +117,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "R\\(L(\\d),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level = std::stoi(match[1]);
         std::string comps_str = match[2];
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
@@ -123,7 +133,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "S\\(L(\\d),L(\\d),(-?\\d+),(-?\\d+),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level1 = std::stoi(match[1]);
         int level2 = std::stoi(match[2]);
         int factor1 = std::stoi(match[3]);
@@ -174,7 +184,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "F\\(L(\\d),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         int level = std::stoi(match[1]);
         std::string comps_str = match[2];
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
@@ -211,7 +221,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
             std::string regex_str = "T1\\(L(\\d),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
             std::regex re(regex_str);
             std::smatch match;
-            std::regex_search(action_str, match, re);
+            parse_or_throw(action_str, match, re);
             int level1 = std::stoi(match[1]);
             int factor1 = std::stoi(match[2]);
             std::string comps_str = match[3];
@@ -230,7 +240,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
             std::string regex_str = "T2\\(L(\\d),L(\\d),(\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
             std::regex re(regex_str);
             std::smatch match;
-            std::regex_search(action_str, match, re);
+            parse_or_throw(action_str, match, re);
             int level1 = std::stoi(match[1]);
             int level2 = std::stoi(match[2]);
             int factor1 = std::stoi(match[3]);
@@ -251,7 +261,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
             std::string regex_str = "T3\\(L(\\d),L(\\d),L(\\d),(\\d+),(\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
             std::regex re(regex_str);
             std::smatch match;
-            std::regex_search(action_str, match, re);
+            parse_or_throw(action_str, match, re);
             int level1 = std::stoi(match[1]);
             int level2 = std::stoi(match[2]);
             int level3 = std::stoi(match[3]);
@@ -279,7 +289,7 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         std::string regex_str = "M\\(\\[([\\d, ]+)\\],comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
-        std::regex_search(action_str, match, re);
+        parse_or_throw(action_str, match, re);
         std::string factors_str = match[1];
         factors_str.erase(std::remove_if(factors_str.begin(), factors_str.end(), isSingleQuoteOrWhiteSpace), factors_str.end());
         std::vector<int> factors;
@@ -325,8 +335,8 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
     }
 
     default:
-        std::cerr << "No action" << std::endl;
-        break;
+        throw std::invalid_argument(
+            "Unknown schedule token: " + action_str);
     }
 
     return is_legal;

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -827,6 +827,19 @@ TEST(TiraLibCppTest, UnrollingLNeg1Mismatch)
   EXPECT_THROW(apply_schedule_multi_comp_sample(schedule), std::invalid_argument);
 }
 
+TEST(TiraLibCppTest, UnknownActionThrows)
+{
+  EXPECT_THROW(apply_schedule_blur("Z(L0,comps=['comp_blur'])"),
+               std::invalid_argument);
+}
+
+TEST(TiraLibCppTest, MalformedActionThrows)
+{
+  // Leading char 'P' is known, but the body is missing the closing paren.
+  EXPECT_THROW(apply_schedule_blur("P(L0,comps=['comp_blur']"),
+               std::invalid_argument);
+}
+
 TEST(TiraLibCppTest, Matrix)
 {
   std::string schedule = "M([0, 1, 0, 1, 0, 0, 0, 0, 1],comps=['comp_blur'])";


### PR DESCRIPTION
Mirror of the TiraLib change [#57](https://github.com/Tiramisu-Compiler/TiraLib/pull/57) Two failure modes were silent or unhelpful:
- `default:` in the switch printed `"No action"` to stderr and returned `is_legal = true`, silently dropping unknown tokens.
- Every `case` ignored `std::regex_search`'s return value, so a malformed body would surface later as a `std::stoi` exception with a useless message.

Both now throw `std::invalid_argument` with the offending token. The regex-check path goes through a small `parse_or_throw` helper used at all 11 call sites.

Tests for an unknown action and a malformed body added in `tests/actions_test.cc`.