### PR TITLE
Fix schedule replay and legality checks

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -19,12 +19,13 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
     container:
-      image: skourta/tiramisu:latest
+      image: mascinissa/tiramisu:looper_master
 
     steps:
     - uses: actions/checkout@v3
     - name: Install Deps
       run: |
+        apt update
         apt install -y sqlite3 libsqlite3-dev zlib1g-dev
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/include/TiraLibCPP/utils.h
+++ b/include/TiraLibCPP/utils.h
@@ -18,6 +18,7 @@ enum Operation
     execution = 1,
     annotations = 2,
     skewing_solver = 3,
+    execution_no_check = 4,
 };
 
 struct Result

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(INCLUDES
-    ${TIRAMISU_INSTALL}/include/
     ${PROJECT_SOURCE_DIR}/include
+    ${TIRAMISU_INSTALL}/include/
 )
 
 option(USE_SQLITE "Use SQLITE" OFF)

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -408,6 +408,9 @@ Result schedule_str_to_result(std::string function_name, std::string schedule_st
 
     tiramisu::prepare_schedules_for_legality_checks();
     is_legal &= tiramisu::check_legality_of_function();
+    // Re-verify parallelization on the final schedule: a parallel tag applied
+    // earlier may have been invalidated by a later interchange/tiling.
+    is_legal &= tiramisu::check_legality_of_parallelism();
     result.legality = is_legal;
     implicit_function->gen_time_space_domain();
     implicit_function->gen_isl_ast();

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -94,6 +94,22 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         {
             comp->unroll(level, factor);
         }
+
+        // Unrolling splits the shared loop of each computation independently,
+        // which fissions computations that were fused into one loop each. The
+        // LOOPer autoscheduler re-establishes the intended fusion afterwards
+        // (via order_computations_from_ast). Replicate that for the unrolled
+        // group: re-issue the .after() ordering at their (now deeper) innermost
+        // loop level so codegen keeps them fused. Without this, a subset-unroll
+        // of mutually dependent computations (e.g. deriche's recursive filter)
+        // is distributed and produces wrong results.
+        if (comps.size() > 1)
+        {
+            int sched_dims = isl_map_dim(comps.front()->get_schedule(), isl_dim_out);
+            int innermost_level = (sched_dims - 2) / 2 - 1;
+            for (size_t i = 1; i < comps.size(); i++)
+                comps[i]->after(*comps[i - 1], innermost_level);
+        }
         break;
     }
     case 'I':

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -147,18 +147,30 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
     }
     case 'S':
     {
-        std::string regex_str = "S\\(L(\\d),L(\\d),(-?\\d+),(-?\\d+),comps=\\[([\\w', ]*)\\]\\)";
-        std::regex re(regex_str);
+        // For [i', j']^T = [[alpha, beta], [gamma, sigma]] [i, j]^T,
+        // the four-factor form supplies the complete matrix in row-major order.
+        // The legacy two-factor form supplies alpha and beta; Tiramisu computes
+        // gamma and sigma such that alpha * sigma - beta * gamma = 1.
+        std::regex four_factor_re(
+            "S\\(L(\\d),L(\\d),(-?\\d+),(-?\\d+),(-?\\d+),(-?\\d+),comps=\\[([\\w', ]*)\\]\\)");
+        std::regex two_factor_re(
+            "S\\(L(\\d),L(\\d),(-?\\d+),(-?\\d+),comps=\\[([\\w', ]*)\\]\\)");
         std::smatch match;
-        parse_or_throw(action_str, match, re);
+        bool has_four_factors = std::regex_search(action_str, match, four_factor_re);
+        if (!has_four_factors)
+        {
+            parse_or_throw(action_str, match, two_factor_re);
+        }
         int level1 = std::stoi(match[1]);
         int level2 = std::stoi(match[2]);
         int factor1 = std::stoi(match[3]);
         int factor2 = std::stoi(match[4]);
-        std::string comps_str = match[5];
+        int factor3 = has_four_factors ? std::stoi(match[5]) : 0;
+        int factor4 = has_four_factors ? std::stoi(match[6]) : 0;
+        std::string comps_str = match[has_four_factors ? 7 : 5];
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
         auto comps = get_comps(comps_str, implicit_function);
-        if (factor1 == 0 && factor2 == 0)
+        if (!has_four_factors && factor1 == 0 && factor2 == 0)
         {
             auto auto_skewing_result = implicit_function->skewing_local_solver(comps, level1, level2, 1);
 
@@ -188,9 +200,20 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         if (is_legal)
         {
             result.additional_info = "skewing_factors:" + std::to_string(factor1) + "," + std::to_string(factor2);
+            if (has_four_factors)
+            {
+                result.additional_info += "," + std::to_string(factor3) + "," + std::to_string(factor4);
+            }
             for (auto comp : comps)
             {
-                comp->skew(level1, level2, factor1, factor2);
+                if (has_four_factors)
+                {
+                    comp->skew(level1, level2, factor1, factor2, factor3, factor4);
+                }
+                else
+                {
+                    comp->skew(level1, level2, factor1, factor2);
+                }
             }
         }
 

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -48,7 +48,10 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
     }
     case 'U':
     {
-        std::string regex_str = "U\\(L(-?\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
+        bool check_only = action_str.rfind("UCheck(", 0) == 0;
+        std::string regex_str = check_only
+            ? "UCheck\\(L(-?\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)"
+            : "U\\(L(-?\\d+),(\\d+),comps=\\[([\\w', ]*)\\]\\)";
         std::regex re(regex_str);
         std::smatch match;
         parse_or_throw(action_str, match, re);
@@ -98,6 +101,9 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         tiramisu::prepare_schedules_for_legality_checks(true);
 
         is_legal = loop_unrolling_is_legal(level, comps);
+
+        if (check_only)
+            break;
 
         for (auto comp : comps)
         {
@@ -449,7 +455,10 @@ Result schedule_str_to_result(std::string function_name, std::string schedule_st
     std::string isl_ast = implicit_function->generate_isl_ast_representation_string(nullptr, 0, "");
     result.isl_ast = isl_ast;
 
-    if (is_legal && operation == Operation::execution)
+    bool should_execute = operation == Operation::execution ||
+                          operation == Operation::execution_no_check;
+    bool legality_required = operation != Operation::execution_no_check;
+    if (should_execute && (is_legal || !legality_required))
     {
         tiramisu::codegen(buffers, function_name + ".o");
 

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1,6 +1,7 @@
 #include <tiramisu/tiramisu.h>
 #include <string>
 #include <regex>
+#include <unordered_set>
 #include <TiraLibCPP/utils.h>
 #include <TiraLibCPP/dbhelpers.h>
 
@@ -29,12 +30,20 @@ bool apply_action(std::string action_str, tiramisu::function *implicit_function,
         int level = std::stoi(match[1]);
         std::string comps_str = match[2];
         comps_str.erase(std::remove_if(comps_str.begin(), comps_str.end(), isSingleQuoteOrWhiteSpace), comps_str.end());
-        auto comps = get_comps(comps_str, implicit_function);
+        auto parsed_comps = get_comps(comps_str, implicit_function);
+        std::vector<tiramisu::computation *> comps;
+        std::unordered_set<tiramisu::computation *> seen;
+        for (auto comp : parsed_comps)
+        {
+            if (seen.insert(comp).second)
+                comps.push_back(comp);
+        }
 
         tiramisu::prepare_schedules_for_legality_checks(true);
         is_legal = tiramisu::loop_parallelization_is_legal(level, comps);
 
-        comps[0]->tag_parallel_level(level);
+        for (auto comp : comps)
+            comp->tag_parallel_level(level);
         break;
     }
     case 'U':

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -68,6 +68,8 @@ Operation get_operation_from_string(std::string operation_str)
         return Operation::execution;
     else if (operation_str == "annotations")
         return Operation::annotations;
+    else if (operation_str == "execution_no_check")
+        return Operation::execution_no_check;
     else
         assert(false && "Unknown operation");
 }

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -392,6 +392,17 @@ TEST(TiraLibCppTest, Unrolling)
             clean_halide_ir(halide_ir));
 }
 
+TEST(TiraLibCppTest, UnrollingCheckOnly)
+{
+  auto [result, halide_ir] =
+      apply_schedule_blur("UCheck(L2,32,comps=['comp_blur'])");
+
+  EXPECT_TRUE(result.legality);
+  EXPECT_EQ(halide_ir.find("unrolled"), std::string::npos);
+  EXPECT_EQ(get_operation_from_string("execution_no_check"),
+            Operation::execution_no_check);
+}
+
 TEST(TiraLibCppTest, UnrollingLNeg1)
 {
   std::string schedule = "U(L-1,32,comps=['comp_blur'])";

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -579,6 +579,34 @@ TEST(TiraLibCppTest, Skewing)
   EXPECT_EQ(clean_halide_ir(global::get_implicit_function()->get_halide_ir({&buf00, &buf01})), clean_halide_ir(halide_ir));
 }
 
+TEST(TiraLibCppTest, SkewingFourFactors)
+{
+  std::string schedule = "S(L0,L1,1,0,1,1,comps=['comp00'])";
+  auto result = apply_schedule_skewing_sample(schedule);
+
+  Result resultInstance = std::get<0>(result);
+  std::string halide_ir = std::get<1>(result);
+
+  tiramisu::init("function550013");
+  var i0("i0", 1, 2049), i1("i1", 1, 2049), i2("i2", 0, 256), i1_p1("i1_p1", 0, 2050), i0_p1("i0_p1", 0, 2050);
+  input icomp00("icomp00", {i0_p1, i1_p1}, p_float64);
+  input input01("input01", {i0_p1}, p_float64);
+  computation comp00("comp00", {i0, i1, i2}, p_float64);
+  comp00.set_expression(icomp00(i0, i1) + icomp00(i0, i1 - 1) * icomp00(i0 + 1, i1) + icomp00(i0, i1 + 1) + icomp00(i0 - 1, i1) + input01(i0) + input01(i0 - 1) - input01(i0 + 1));
+  buffer buf00("buf00", {2050, 2050}, p_float64, a_output);
+  buffer buf01("buf01", {2050}, p_float64, a_input);
+  icomp00.store_in(&buf00);
+  input01.store_in(&buf01);
+  comp00.store_in(&buf00, {i0, i1});
+
+  comp00.skew(0, 1, 1, 0, 1, 1);
+
+  EXPECT_EQ(resultInstance.legality, true);
+  EXPECT_EQ(resultInstance.additional_info, "skewing_factors:1,0,1,1");
+  EXPECT_EQ(global::get_implicit_function()->get_name(), "function550013");
+  EXPECT_EQ(clean_halide_ir(global::get_implicit_function()->get_halide_ir({&buf00, &buf01})), clean_halide_ir(halide_ir));
+}
+
 std::tuple<Result, std::string> apply_schedule_multi_comp_sample(std::string schedule)
 {
   auto function_name = "function_gemver_MINI";

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -67,6 +67,45 @@ std::string clean_halide_ir(std::string ir)
   return result2;
 }
 
+std::tuple<Result, std::string> apply_schedule_parallel_group(std::string schedule)
+{
+  std::string function_name = "function_parallel_group";
+  tiramisu::init(function_name);
+
+  var i("i", 0, 16);
+  computation first("first", {i}, 1);
+  computation second("second", {i}, 2);
+  computation third("third", {i}, 3);
+
+  // first and second share one loop; third is in a separate root loop.
+  first.then(second, i).then(third, computation::root_dimension);
+
+  buffer b_first("b_first", {16}, p_int32, a_output);
+  buffer b_second("b_second", {16}, p_int32, a_output);
+  buffer b_third("b_third", {16}, p_int32, a_output);
+  first.store_in(&b_first);
+  second.store_in(&b_second);
+  third.store_in(&b_third);
+
+  std::vector<buffer *> buffers = {&b_first, &b_second, &b_third};
+  auto result = schedule_str_to_result(
+      function_name, schedule, Operation::legality, buffers);
+  auto halide_ir = global::get_implicit_function()->get_halide_ir(buffers);
+  return std::make_tuple(result, halide_ir);
+}
+
+size_t count_occurrences(const std::string &text, const std::string &needle)
+{
+  size_t count = 0;
+  size_t position = 0;
+  while ((position = text.find(needle, position)) != std::string::npos)
+  {
+    count++;
+    position += needle.size();
+  }
+  return count;
+}
+
 // Demonstrate some basic assertions.
 TEST(TiraLibCppTest, ParallelizationCheck)
 {
@@ -170,6 +209,28 @@ TEST(TiraLibCppTest, ParallelizationCheckL1)
 
   EXPECT_EQ(global::get_implicit_function()->get_name(), function_name);
   EXPECT_EQ(clean_halide_ir(global::get_implicit_function()->get_halide_ir(buffers)), clean_halide_ir(halide_ir));
+}
+
+TEST(TiraLibCppTest, ParallelizationTagsFusedAndIndependentLoops)
+{
+  auto [result, halide_ir] = apply_schedule_parallel_group(
+      "P(L0,comps=['first','second','third'])");
+
+  EXPECT_TRUE(result.legality);
+  // first and second share one parallel loop, while third has its own.
+  EXPECT_EQ(count_occurrences(halide_ir, "parallel ("), 2);
+}
+
+TEST(TiraLibCppTest, DuplicateParallelizationTargetsAreIdempotent)
+{
+  auto [unique_result, unique_ir] = apply_schedule_parallel_group(
+      "P(L0,comps=['first','second','third'])");
+  auto [duplicate_result, duplicate_ir] = apply_schedule_parallel_group(
+      "P(L0,comps=['first','second','second','third','first'])");
+
+  EXPECT_TRUE(unique_result.legality);
+  EXPECT_TRUE(duplicate_result.legality);
+  EXPECT_EQ(clean_halide_ir(duplicate_ir), clean_halide_ir(unique_ir));
 }
 
 TEST(TiraLibCppTest, Tiling2D)


### PR DESCRIPTION
## Summary

This PR brings the C++ schedule executor in line with the schedule semantics used by iraLib. It fixes group unrolling, final-schedule parallel legality, complete skew-matrix parsing, multi-computation parallelization, and explicit subset unrolling.

The Python-side changes are in [TiraLib PR #58](https://github.com/Tiramisu-Compiler/TiraLib/pull/58). The final parallelism check requires [Tiramisu PR #422](https://github.com/Tiramisu-Compiler/tiramisu/pull/422).

## Changes

### Keep computation groups fused after unrolling

Commit [75f959b](https://github.com/Mascinissa/TiraLibCpp/commit/75f959b53702fcdad9a4a92b58fdf4b86e51a3f9) restores the `.after()` ordering of a computation group after applying `unroll()` to its members.

Each `computation::unroll()` call splits that computation's loop independently. Applying it to every member of a fused group can therefore introduce loop fission and change the meaning of schedules with dependencies inside that loop. The handler now re-fuses the group at its new innermost level. Single-computation unrolls are unaffected.

The Python equivalent is [TiraLib `861caab`](https://github.com/Mascinissa/TiraLib/commit/861caab4713ff7d4029400b82d12b5c19a8a2f0f).

### Check parallelization against the final schedule

Commit [e0b6be2](https://github.com/Mascinissa/TiraLibCpp/commit/e0b6be2bbc04cc462f007b2e9dd7464fc9e65018) runs `tiramisu::check_legality_of_parallelism()` after all schedule actions have been applied.

A parallel tag is attached to a loop level when the action is processed. Later loop transformations can change which loop occupies that level, making the original legality decision stale. Rechecking the recorded tags on the final schedule fixes the parallelize-then-interchange case from [TiraLib issue #34](https://github.com/Tiramisu-Compiler/TiraLib/issues/34).

This commit depends on [Tiramisu `d7ad1e8b`](https://github.com/Mascinissa/tiramisu/commit/d7ad1e8bea84ac5faced2de36c584465770f28fa). The Python equivalent is [TiraLib `9ade86a`](https://github.com/Mascinissa/TiraLib/commit/9ade86a20ff4691e54fdacb5ccec59138874a0fe).

### Support complete two-dimensional skew matrices

Commit [067dafe](https://github.com/Mascinissa/TiraLibCpp/commit/067dafe6607ef1a6dfb613f6f93d65d182fc8932) extends the `S(...)` parser with a four-factor form:

```text
S(Li,Lj,alpha,beta,gamma,sigma,...)

[i']   [alpha  beta ] [i]
[j'] = [gamma  sigma] [j]
```

The existing two-factor form supplies only the first row and relies on Tiramisu to solve for the second. Since that form cannot represent every valid unimodular matrix, the new syntax passes the complete matrix to Tiramisu's four-factor skew overload. The old syntax, including automatic factor selection, remains unchanged.

The Python parser is updated in [TiraLib `fc425d3`](https://github.com/Mascinissa/TiraLib/commit/fc425d36fcc48756a824d744a73c0b951e29c68d), and Tiramisu emits the lossless form in [Tiramisu `5fc025f8`](https://github.com/Mascinissa/tiramisu/commit/5fc025f81ec40a45874b7d8a0ab208449346b668).

### Apply parallelization to every selected computation

Commit [a666990](https://github.com/Mascinissa/TiraLibCpp/commit/a666990c9b96f396e8d9b992cbb826f0524c7245) tags every distinct computation listed in `P(...)`.

The handler previously checked the complete list for legality but called `tag_parallel_level()` only on its first member. That assumption is valid for a completely fused group, but it leaves independent loops serial. The parser now deduplicates the resolved computation pointers and tags each one. Repeated tags for a shared fused loop still produce one parallel loop.

The Python equivalent is [TiraLib `4f16a31`](https://github.com/Mascinissa/TiraLib/commit/4f16a3145dc5a5b3a272592367397a86a6b84c2d).

### Support legality-checked subset unrolling

Commit [03d818c](https://github.com/Mascinissa/TiraLibCpp/commit/03d818c18001d28e7095faba487103f171e4c098) adds the internal `UCheck(...)` action and `execution_no_check` operation needed to replay an explicit subset unroll without widening its target.

Tiramisu's specialized unrolling legality check expects the complete computation group for a fused loop, while execution must apply the transformation only to the computations listed in the schedule. `UCheck(...)` validates the full group without mutating the legality schedule. After that succeeds, TiraLib starts a fresh server process and applies the original `U(...)` action to the exact subset. The unchecked execution operation is internal and is selected only after a successful legality result.

This commit also puts the source tree's headers before installed headers during the build, preventing an older installed protocol definition from shadowing the version being built. Full-loop `U(...)` actions keep their existing path.

The coordinating Python changes are in [TiraLib `1c7ba19`](https://github.com/Mascinissa/TiraLib/commit/1c7ba1929940d89cb2d9cfa3b7bff5abc2ec35b5).

## Compatibility

- Existing two-factor skew strings remain valid.
- Full-loop unrolling keeps the existing `U(...)` behavior.
- Single-computation unrolling is unchanged.
- Duplicate parallel targets are idempotent.

## Testing

- TiraLibCpp test suite: 22 passed.
- Added regression coverage for final-schedule parallel legality, four-factor skew parsing, computation-group parallelization, duplicate targets, `UCheck(...)`, and checked subset execution.
