### PR TITLE
Avoid building an ISL AST for illegal schedules

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -450,10 +450,17 @@ Result schedule_str_to_result(std::string function_name, std::string schedule_st
     // earlier may have been invalidated by a later interchange/tiling.
     is_legal &= tiramisu::check_legality_of_parallelism();
     result.legality = is_legal;
-    implicit_function->gen_time_space_domain();
-    implicit_function->gen_isl_ast();
-    std::string isl_ast = implicit_function->generate_isl_ast_representation_string(nullptr, 0, "");
-    result.isl_ast = isl_ast;
+    // Code-generation AST construction is only valid after the transformed
+    // schedule passes legality.  Besides avoiding work for rejected schedules,
+    // this keeps illegal helper/update domains out of ISL's AST builder.
+    if (is_legal)
+    {
+        implicit_function->gen_time_space_domain();
+        implicit_function->gen_isl_ast();
+        result.isl_ast =
+            implicit_function->generate_isl_ast_representation_string(
+                nullptr, 0, "");
+    }
 
     bool should_execute = operation == Operation::execution ||
                           operation == Operation::execution_no_check;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,5 +1,6 @@
 #include <tiramisu/tiramisu.h>
 #include <TiraLibCPP/utils.h>
+#include <unordered_set>
 // #include "function_floyd_warshall_MINI_wrapper.h"
 
 using namespace tiramisu;
@@ -47,16 +48,21 @@ std::string get_first_comp(std::string comps_str)
 std::vector<tiramisu::computation *> get_comps(std::string comps_str, tiramisu::function *implicit_function)
 {
     std::vector<tiramisu::computation *> comps;
+    std::unordered_set<tiramisu::computation *> seen;
     std::string delimiter = ",";
     size_t pos = 0;
     std::string token;
     while ((pos = comps_str.find(delimiter)) != std::string::npos)
     {
         token = comps_str.substr(0, pos);
-        comps.push_back(get_computation_by_name(token, implicit_function));
+        auto comp = get_computation_by_name(token, implicit_function);
+        if (seen.insert(comp).second)
+            comps.push_back(comp);
         comps_str.erase(0, pos + delimiter.length());
     }
-    comps.push_back(get_computation_by_name(comps_str, implicit_function));
+    auto comp = get_computation_by_name(comps_str, implicit_function);
+    if (seen.insert(comp).second)
+        comps.push_back(comp);
     return comps;
 }
 

--- a/tests/actions_test.cc
+++ b/tests/actions_test.cc
@@ -233,6 +233,17 @@ TEST(TiraLibCppTest, DuplicateParallelizationTargetsAreIdempotent)
   EXPECT_EQ(clean_halide_ir(duplicate_ir), clean_halide_ir(unique_ir));
 }
 
+TEST(TiraLibCppTest, DuplicateTilingTargetsAreIdempotent)
+{
+  auto [unique_result, unique_ir] = apply_schedule_blur(
+      "T2(L0,L1,4,4,comps=['comp_blur'])");
+  auto [duplicate_result, duplicate_ir] = apply_schedule_blur(
+      "T2(L0,L1,4,4,comps=['comp_blur','comp_blur','comp_blur'])");
+
+  EXPECT_EQ(duplicate_result.legality, unique_result.legality);
+  EXPECT_EQ(clean_halide_ir(duplicate_ir), clean_halide_ir(unique_ir));
+}
+
 TEST(TiraLibCppTest, Tiling2D)
 {
   std::string schedule = "T2(L0,L1,32,32,comps=['comp_blur'])";
@@ -591,6 +602,7 @@ TEST(TiraLibCppTest, IllegalAction)
   std::string halide_ir = std::get<1>(result);
 
   EXPECT_EQ(resultInstance.legality, false);
+  EXPECT_TRUE(resultInstance.isl_ast.empty());
 }
 
 std::tuple<Result, std::string> apply_schedule_skewing_sample(std::string schedule)


### PR DESCRIPTION
Companion Python changes: [TiraLib PR #59](https://github.com/Tiramisu-Compiler/TiraLib/pull/59).

The server used to call `gen_time_space_domain()` and `gen_isl_ast()` even after the schedule had failed legality checks. For some invalid transformed domains, that AST construction can take hours or use excessive memory.

The server now builds and returns an ISL AST only when the final legality result is `true`. Legal schedules are unchanged. Illegal schedules return their verdict with an empty AST.

The shared computation-list parser now also removes duplicate computation pointers while preserving their first occurrence. This prevents repeated names in a schedule string from applying actions such as tiling more than once.


Tests cover empty ASTs for illegal schedules and verify that repeated tiling targets are equivalent to a single target. The TiraLibCpp suite passes all 23 tests.